### PR TITLE
Create backend to connect to pgrx extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ pgrx = "0.13.1"
 serde = "1.0.210"
 serde_json = "1.0.128"
 
+# Tide dependencies
+tide = { version = "0.17.0-beta.1" }
+async-std = { version = "1.8.0", features = ["attributes"] }
+
 [dev-dependencies]
 pgrx-tests = "0.13.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pg_test = []
 
 [dependencies]
 pgrx = "0.13.1"
+sqlx = { version = "0.7", features = ["runtime-async-std-native-tls", "postgres"] }
 serde = "1.0.210"
 serde_json = "1.0.128"
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ Running project
 4. When making changes, after compiling must drop the extension and re-add it with
    `DROP EXTENSION hypostats` and `CREATE EXTENSION hypostats`
 
-TESTING
+Running backend server
 
-- Find column in pg_statistic that we want to modify
-- Get the json dump with pg_statistic_dump
-- Modify the attribute with pg_modify_stats
-- Take the new json dump and load with pg_statistic_load
-- Verify the statistic is updated
+1. Modify the postgres connection in the main function of main.rs to connect
+   To find the correct port, you can run `cargo pgrx run` and it will say: Starting
+   Postgres vXXX on port XXX
+   To find the username, run `\du` in the Postgres terminal
+2. Run `cargo run --bin hypostats` to get the backend up
+3. Make http requests from localhost on port 8080 like so to get pg_statistic dumps:
+   curl localhost:8080/query -d '{ "starelid": 41281, "staattnum": 1 }'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,24 +1064,20 @@ fn pg_statistic_modify(
 }
 
 #[pg_extern]
-pub fn spi_return_query(query: String) -> String {
+pub fn spi_return_stats(starelid: i32, staattnum: i32) -> String {
     Spi::connect(|client| {
-        // let result = client.select(&query, None, &[]);
-        // let mut output: String = String::new();
+        let query = format!("SELECT pg_statistic_dump({}, CAST ({} as SMALLINT))", starelid, staattnum);
+        let result = client.select(&query, None, &[]).unwrap();
+        let mut out = String::new();
 
-        // if let Ok(row) = result {
-        //     let num_cols = row.columns().unwrap();
-        //     let mut row_values = Vec::new();
-
-        //     for col in 1..=num_cols {
-        //         let value: Option<String> = row.get(col).unwrap_or(None);
-        //         row_values.push(value.unwrap_or_else(|| "NULL".to_string()));
-        //     }
-
-        //     output = format!("{}\n{}", output, row_values.join(", "));
-        // }
-        // output
-        "abcdef".to_ascii_lowercase()
+        for row in result {
+            for col in 1..=row.columns() {
+                let val: Option<String> = row.get(col).unwrap();
+                out.push_str(&format!("{}\t", val.unwrap_or_else(|| "NULL".to_string())));
+            }
+            out.push('\n');
+        }
+        out
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,6 +1064,28 @@ fn pg_statistic_modify(
 }
 
 #[pg_extern]
+pub fn spi_return_query(query: String) -> String {
+    Spi::connect(|client| {
+        // let result = client.select(&query, None, &[]);
+        // let mut output: String = String::new();
+
+        // if let Ok(row) = result {
+        //     let num_cols = row.columns().unwrap();
+        //     let mut row_values = Vec::new();
+
+        //     for col in 1..=num_cols {
+        //         let value: Option<String> = row.get(col).unwrap_or(None);
+        //         row_values.push(value.unwrap_or_else(|| "NULL".to_string()));
+        //     }
+
+        //     output = format!("{}\n{}", output, row_values.join(", "));
+        // }
+        // output
+        "abcdef".to_ascii_lowercase()
+    })
+}
+
+#[pg_extern]
 fn anyarray_elemtype(x: pgrx::AnyArray) -> Option<pg_sys::Oid> {
     // Get the type of the elements of the array using pg_sys.
     unsafe { aarr_elemtype(x.datum().cast_mut_ptr()) }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,60 @@
+extern crate tide;
+use pgrx::Spi;
+use tide::Request;
+use tide::prelude::*;
+// use hypostats::spi_return_query;
+
+#[derive(Debug, Deserialize)]
+struct Animal {
+    query: String,
+    legs: u16,
+}
+
+fn spi_return_query(_query: String) -> String {
+    Spi::connect(|_client| {
+        // let result = client.select(&query, None, &[]);
+        // let mut output: String = String::new();
+
+        // if let Ok(row) = result {
+        //     let num_cols = row.columns().unwrap();
+        //     let mut row_values = Vec::new();
+
+        //     for col in 1..=num_cols {
+        //         let value: Option<String> = row.get(col).unwrap_or(None);
+        //         row_values.push(value.unwrap_or_else(|| "NULL".to_string()));
+        //     }
+
+        //     output = format!("{}\n{}", output, row_values.join(", "));
+        // }
+        // output
+        "abcdef".to_ascii_lowercase()
+    })
+}
+
+// #[async_std::main]
+// async fn main() -> tide::Result<()> {
+//     let mut app = tide::new();
+//     app.at("/orders/shoes").post(order_shoes);
+//     app.listen("127.0.0.1:8080").await?;
+//     Ok(())
+// }
+
+fn main() {
+  let result = spi_return_query("hello".to_ascii_lowercase());
+  println!("{}", result);
+  // println!("Hello");
+}
+
+// fn order_shoes(mut req: Request<()>) -> tide::Result {
+//     let Animal { query, legs } = req.body_json();
+//     let query_result: String = spi_return_query(query);
+//     // let query_result = query;
+//     Ok(format!("Result is: {}, legs: {}\n", query_result, legs).into())
+// }
+
+async fn order_shoes(mut req: Request<()>) -> tide::Result {
+    let Animal { query, legs } = req.body_json().await?;
+    let query_result: String = spi_return_query(query);
+    // let query_result = query;
+    Ok(format!("Result is: {}, legs: {}\n", query_result, legs).into())
+}


### PR DESCRIPTION
Allow users to make pg_statistic_dump requests through HTTP. 

TODO:
- Add more functionality, maybe like a getFullDump(relname) sort of request that exports all statistics from a given table along with the relevant pg_class and pg_attribute information